### PR TITLE
fix https://stackoverflow.com/questions/75370815/pylint-specifying-ex…

### DIFF
--- a/pipelines/.pylintrc
+++ b/pipelines/.pylintrc
@@ -1,9 +1,8 @@
-[MASTER]
+[MAIN]
 
 # A comma-separated list of package or module names from where C extensions may
 # be loaded. Extensions are loading into the active Python interpreter and may
 # run arbitrary code.
-extension-pkg-whitelist=
 
 # Specify a score threshold to be exceeded before program exits with error.
 fail-under=9.0
@@ -505,5 +504,5 @@ preferred-modules=
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "BaseException, Exception".
-overgeneral-exceptions=BaseException,
-                       Exception
+overgeneral-exceptions=builtins.BaseException,
+                       builtins.Exception


### PR DESCRIPTION
…ception-names-in-the-overgeneral-exceptions-option-without